### PR TITLE
TextDocumentService/documentHighlight should return a DocumentHighlight[]

### DIFF
--- a/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/TextDocumentService.xtend
+++ b/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/TextDocumentService.xtend
@@ -78,7 +78,7 @@ interface TextDocumentService {
      * The document highlight request is sent from the client to the server to to resolve a document highlights for a
      * given text document position.
      */
-    def CompletableFuture<DocumentHighlight> documentHighlight(TextDocumentPositionParams position)
+    def CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(TextDocumentPositionParams position)
     
     /**
      * The document symbol request is sent from the client to the server to list all symbols found in a given text document.

--- a/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/transport/client/LanguageClientEndpoint.xtend
+++ b/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/transport/client/LanguageClientEndpoint.xtend
@@ -237,7 +237,7 @@ class LanguageClientEndpoint extends AbstractLanguageEndpoint implements Languag
         }
         
         override documentHighlight(TextDocumentPositionParams position) {
-            connection.getPromise(DOC_HIGHLIGHT, position, DocumentHighlight)
+            connection.getListPromise(DOC_HIGHLIGHT, position, DocumentHighlight)
         }
         
         override documentSymbol(DocumentSymbolParams params) {


### PR DESCRIPTION
TextDocumentService/documentHighlight should return a DocumentHighlight[]. Fixes #40

Signed-off-by: Christian Dietrich christian.dietrich@itemis.de
