### PR TITLE
Add initializationOptions to InitializeParams

### DIFF
--- a/io.typefox.lsapi/src/main/java/io/typefox/lsapi/InitializeParams.xtend
+++ b/io.typefox.lsapi/src/main/java/io/typefox/lsapi/InitializeParams.xtend
@@ -29,6 +29,12 @@ interface InitializeParams {
 	def String getRootPath()
 	
 	/**
+	 * User provided initialization options.
+	 */
+	@Nullable
+	def Object getInitializationOptions()
+	
+	/**
 	 * The capabilities provided by the client (editor)
 	 */
 	@Nullable


### PR DESCRIPTION
The `InitializeParams.initializationOptions` has just been added to the
protocol:
https://github.com/Microsoft/language-server-protocol/issues/55

Signed-off-by: Kaloyan Raev kaloyan.r@zend.com
