### PR TITLE
Add com.google.gson to p2 repo

### DIFF
--- a/gradle/maven-tycho-p2-repository/category.xml
+++ b/gradle/maven-tycho-p2-repository/category.xml
@@ -19,4 +19,8 @@
       <category name="lsapi"/>
    </bundle>
    <category-def name="lsapi" label="lsapi"/>
+   <bundle id="com.google.gson">
+      <category name="deps"/>
+   </bundle>
+   <category-def name="deps" label="dependencies"/>
 </site>


### PR DESCRIPTION
For us Eclipse/OSGi devs using ls-api, due to an Eclipse/PDE limtiation, it's a bit annoying to  setup a PDE target platform for libraries that are not avaiable as OSGi bundles. `com.google.gson` version 2.5.0 is one of those bundles, so it would be quite useful if this was added to the p2 repo in http://services.typefox.io/open-source/jenkins///job/lsapi/lastSuccessfulBuild/artifact/build/p2-repository/
This PR whould achieve that.
