### PR TITLE
Fixed the value of the log message type.

### DIFF
--- a/io.typefox.lsapi/src/main/java/io/typefox/lsapi/MessageType.java
+++ b/io.typefox.lsapi/src/main/java/io/typefox/lsapi/MessageType.java
@@ -27,7 +27,7 @@ public enum MessageType {
 	/**
 	 * A log message.
 	 */
-	Log(1);
+	Log(4);
 	
 	private final int value;
 	


### PR DESCRIPTION
According to the [specification](https://github.com/Microsoft/language-server-protocol/blame/master/protocol.md#L683) this should be 4 instead of 1.

Please make sure to apply this change to the LSP4J repository once it is in place.

Signed-off-by: Akos Kitta kittaakos@gmail.com
