### PR TITLE
Fix typo in WorkspaceService

### DIFF
--- a/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/WorkspaceService.xtend
+++ b/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/WorkspaceService.xtend
@@ -25,7 +25,7 @@ interface WorkspaceService {
     /**
      * A notification sent from the client to the server to signal the change of configuration settings.
      */
-    def void didChangeConfiguraton(DidChangeConfigurationParams params)
+    def void didChangeConfiguration(DidChangeConfigurationParams params)
     
     /**
      * The watched files notification is sent from the client to the server when the client detects changes to

--- a/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/transport/client/LanguageClientEndpoint.xtend
+++ b/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/transport/client/LanguageClientEndpoint.xtend
@@ -322,7 +322,7 @@ class LanguageClientEndpoint extends AbstractLanguageEndpoint implements Languag
             connection.getListPromise(WORKSPACE_SYMBOL, params, SymbolInformation)
         }
         
-        override didChangeConfiguraton(DidChangeConfigurationParams params) {
+        override didChangeConfiguration(DidChangeConfigurationParams params) {
             connection.sendNotification(DID_CHANGE_CONF, params)
         }
         

--- a/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/transport/server/LanguageServerEndpoint.xtend
+++ b/io.typefox.lsapi.services/src/main/java/io/typefox/lsapi/services/transport/server/LanguageServerEndpoint.xtend
@@ -203,7 +203,7 @@ class LanguageServerEndpoint extends AbstractLanguageEndpoint {
                 case DID_SAVE_DOC:
                     delegate.textDocumentService.didSave(message.params as DidSaveTextDocumentParams)
                 case DID_CHANGE_CONF:
-                    delegate.workspaceService.didChangeConfiguraton(message.params as DidChangeConfigurationParams)
+                    delegate.workspaceService.didChangeConfiguration(message.params as DidChangeConfigurationParams)
                 case DID_CHANGE_FILES:
                     delegate.workspaceService.didChangeWatchedFiles(message.params as DidChangeWatchedFilesParams)
                 case CANCEL:

--- a/io.typefox.lsapi.services/src/test/java/io/typefox/lsapi/services/test/MockedLanguageServer.xtend
+++ b/io.typefox.lsapi.services/src/test/java/io/typefox/lsapi/services/test/MockedLanguageServer.xtend
@@ -282,7 +282,7 @@ class MockedLanguageServer implements LanguageServer {
 			return server.promise
 		}
 		
-		override didChangeConfiguraton(DidChangeConfigurationParams params) {
+		override didChangeConfiguration(DidChangeConfigurationParams params) {
 			server.methodCalls.put('didChangeConfiguraton', params)
 		}
 		


### PR DESCRIPTION
`didChangeConfiguraton` -> `didChangeConfiguration`
